### PR TITLE
fix: Add missing ZenHub token input

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,9 @@ inputs:
     org-token:
         required: true
         description: 'Github token with read only access to organization'
+    zenhub-token:
+        required: true
+        description: 'ZenHub API token'
 runs:
     using: 'node16'
     main: 'dist/index.js'


### PR DESCRIPTION
The `zenhub-token` input was missing, so even though the action worked, it was showing a warning that it got an unexpected input:
<img width="699" alt="Screenshot 2023-02-01 at 11 49 43" src="https://user-images.githubusercontent.com/2934111/216022749-d897ddaa-3847-419f-8525-a1ce155b6be4.png">
This fixes it.