### PR TITLE
chore: More explicit message when missing estimate

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -296,7 +296,7 @@ export async function ensureCorrectLinkingAndEstimates(pullRequest: PullRequest,
     ) await fail(pullRequest, 'Pull request is neither linked to an issue or epic nor labeled as adhoc!', octokit, isDryRun);
 
     if (!linkedIssue && !pullRequestEstimate) {
-        await fail(pullRequest, 'If issue is not linked to the pull request then estimate the pull request!', octokit, isDryRun);
+        await fail(pullRequest, 'If issue is not linked to the pull request then estimate the pull request in Zenhub!', octokit, isDryRun);
     }
     if (!linkedIssue) return;
 


### PR DESCRIPTION
To clearly indicate what does the user need to do outside of GitHub.
(Spent 20 minutes searching pure GitHub for "estimate" field.)